### PR TITLE
Don't report an error for redirects in ignored routes.

### DIFF
--- a/bottle_swagger.py
+++ b/bottle_swagger.py
@@ -64,8 +64,11 @@ class SwaggerPlugin:
                 return self.swagger.spec_dict
 
     def _swagger_validate(self, callback, route, *args, **kwargs):
+        swagger_op = self._swagger_op(route)
+        if not swagger_op and self.ignore_undefined_routes:
+            return callback(*args, **kwargs)
+
         try:
-            swagger_op = self._swagger_op(route)
             if not swagger_op and not self.ignore_undefined_routes and not self._is_swagger_schema_route(route):
                 return self.swagger_op_not_found_handler(route)
 


### PR DESCRIPTION
This was a fun one. I had an app that is serving both a rest api, as well as the docs (via swagger ui). I wanted `/docs` to redirect to `/docs/index.html` to make swagger ui happy. So the app looked like:

```
import os
import yaml
import bottle
from bottle_swagger import SwaggerPlugin

# Set up swagger
this_dir = os.path.dirname(os.path.abspath(__file__))
with open("{0}/swagger.yml".format(this_dir)) as f:
    swagger_def = yaml.load(f)

bottle.install(SwaggerPlugin(swagger_def, ignore_undefined_routes=True))

@bottle.route('/docs')
def docs_index():
    bottle.redirect("/docs/index.html")

@bottle.route('/docs/<filename:path>')
def docs(filename):
    return bottle.static_file(filename, root=this_dir + "/swagger-ui")
```

However, this wouldn't work - I kept getting `{"code": 500, "message": ""}`.

Turns out, this is because `_swagger_validate` catches _all_ exceptions, and returns this generic error. Bottle implements redirects as exceptions, so.

This solution I use is to immediately return from _swagger_validate if the route is not a swagger one and 'ignore_undefined_routes' is True.

Incidentally, the reason 'message' is empty above is because bottle raises an HTTPRespose as the exception, which has no `__str__` method. It does have `__repr__`, though.
