### PR TITLE
Unimplemented exception for query

### DIFF
--- a/bottle_swagger.py
+++ b/bottle_swagger.py
@@ -122,6 +122,10 @@ class BottleIncomingRequest(IncomingRequest):
     def json(self):
         return self.request.json
 
+    @property
+    def query(self):
+        return self.request.query
+
 
 class BottleOutgoingResponse(OutgoingResponse):
     def __init__(self, bottle_response, response_json):

--- a/example/app.py
+++ b/example/app.py
@@ -20,6 +20,13 @@ def hello(thing_id):
     return {"id": thing_id, "name": "Thing{}".format(thing_id)}
 
 
+@bottle.get('/thing_query')
+def hello():
+    thing_id = bottle.request.query['thing_id']
+    return {"id": thing_id, "name": "Thing{}".format(thing_id)}
+
+
 @bottle.post('/thing')
 def hello():
     return bottle.request.json
+

--- a/example/swagger.yml
+++ b/example/swagger.yml
@@ -34,3 +34,11 @@ paths:
         '200':
           description: ''
           schema: {$ref: '#/definitions/Thing'}
+  "/thing_query":
+    get:
+      parameters:
+      - {in: query, name: thing_id, required: true, type: string}
+      responses:
+        '200':
+          description: ''
+          schema: {$ref: '#/definitions/Thing'}

--- a/test/test_bottle_swagger.py
+++ b/test/test_bottle_swagger.py
@@ -72,6 +72,24 @@ class TestBottleSwagger(TestCase):
                         }
                     }
                 }
+            },
+            "/thing_query": {
+                "get": {
+                    "parameters": [{
+                        "name": "thing_id",
+                        "in": "query",
+                        "required": True,
+                        "type": "string"
+                    }],
+                    "responses": {
+                        "200": {
+                            "description": "",
+                            "schema": {
+                                "$ref": "#/definitions/Thing"
+                            }
+                        }
+                    }
+                }
             }
         }
     }
@@ -136,6 +154,10 @@ class TestBottleSwagger(TestCase):
 
     def test_path_parameters(self):
         response = self._test_request(url="/thing/123", route_url="/thing/<thing_id>")
+        self.assertEqual(response.status_int, 200)
+
+    def test_query_parameters(self):
+        response = self._test_request(url="/thing_query?thing_id=123", route_url="/thing_query")
         self.assertEqual(response.status_int, 200)
 
     def test_get_swagger_schema(self):


### PR DESCRIPTION
Resolved unimplemented exceptions for query with latest bravado-core (v4.2.4).

Before

```
$ curl -XGET 'http://localhost:8080/thing_query?thing_id=123'
{"message": "This IncomingRequest type <class 'bottle_swagger.BottleIncomingRequest'> forgot to implement an attr for `query`", "code": 500}(swagger-debug)
```

After

```
$ curl -XGET 'http://localhost:8080/thing_query?thing_id=123'
{"name": "Thing123", "id": "123"}
```
