### PR TITLE
Enable header and formData

### DIFF
--- a/bottle_swagger.py
+++ b/bottle_swagger.py
@@ -126,6 +126,13 @@ class BottleIncomingRequest(IncomingRequest):
     def query(self):
         return self.request.query
 
+    @property
+    def headers(self):
+        return self.request.headers
+
+    @property
+    def form(self):
+        return self.request.forms
 
 class BottleOutgoingResponse(OutgoingResponse):
     def __init__(self, bottle_response, response_json):

--- a/example/app.py
+++ b/example/app.py
@@ -26,6 +26,18 @@ def hello():
     return {"id": thing_id, "name": "Thing{}".format(thing_id)}
 
 
+@bottle.get('/thing_header')
+def hello():
+    thing_id = bottle.request.headers['thing_id']
+    return {"id": thing_id, "name": "Thing{}".format(thing_id)}
+
+
+@bottle.post('/thing_formdata')
+def hello():
+    thing_id = bottle.request.forms['thing_id']
+    return {"id": thing_id, "name": "Thing{}".format(thing_id)}
+
+
 @bottle.post('/thing')
 def hello():
     return bottle.request.json

--- a/example/swagger.yml
+++ b/example/swagger.yml
@@ -42,3 +42,20 @@ paths:
         '200':
           description: ''
           schema: {$ref: '#/definitions/Thing'}
+  "/thing_header":
+    get:
+      parameters:
+      - {in: header, name: thing_id, required: true, type: string}
+      responses:
+        '200':
+          description: ''
+          schema: {$ref: '#/definitions/Thing'}
+  "/thing_formdata":
+    post:
+      consumes: ['application/x-www-form-urlencoded', 'multipart/form-data']
+      parameters:
+      - {in: formData, name: thing_id, required: true, type: string}
+      responses:
+        '200':
+          description: ''
+          schema: {$ref: '#/definitions/Thing'}


### PR DESCRIPTION
Resolved unimplemented exceptions for header and formData with latest bravado-core (v4.2.4).

```
$ curl -XGET http://localhost:8080/thing_header -H 'thing_id:123'
{"id": "123", "name": "Thing123"}
$ curl -XPOST http://localhost:8080/thing_formdata -F 'thing_id=123'
{"name": "Thing123", "id": "123"}
```
